### PR TITLE
Enable :if and :unless options of ActiveSupport::Callbacks

### DIFF
--- a/lib/preserve/extension.rb
+++ b/lib/preserve/extension.rb
@@ -5,7 +5,7 @@ module Preserve
   module Extension
     def preserve(*parameter_keys)
       options = parameter_keys.extract_options!
-      filter_options = options.slice(:only, :except)
+      filter_options = options.slice(:only, :except, :if, :unless)
 
       parameter_keys.each do |parameter_key|
         callback = Callback.new(self, parameter_key, options)

--- a/spec/preserve_spec.rb
+++ b/spec/preserve_spec.rb
@@ -44,6 +44,15 @@ RSpec.describe Preserve, type: :request do
     expect(json_response[:status]).to eq(nil)
   end
 
+  it 'applies callback conditional options' do
+    ParametersController.preserve(:status, if: -> { false })
+
+    get parameters_path, params: { status: 'active' }
+    get parameters_path
+
+    expect(json_response[:status]).to eq(nil)
+  end
+
   it 'supports controller inheritance' do
     ApplicationController.preserve(:locale)
 


### PR DESCRIPTION
Using `:if` and `:unless` options (of ActiveSupport::Callbacks) you can write something like

```
preserve :status, if: :method
```
or 

```
preserve :status, unless: -> { condition }
```
