### PR TITLE
Ensure session stored object are native types

### DIFF
--- a/lib/preserve/callback.rb
+++ b/lib/preserve/callback.rb
@@ -49,7 +49,9 @@ module Preserve
 
     def parameter_value
       keys = Array(parameter_key)
-      keys.reduce(params) { |h, k| h[k] if h.is_a?(PARAMETERS_CLASS) }
+      value = keys.reduce(params) { |h, k| h[k] if h.is_a?(PARAMETERS_CLASS) }
+      value = parameters_to_hash(value) if value.is_a?(PARAMETERS_CLASS)
+      value
     end
 
     def parameter_value=(value)
@@ -64,6 +66,11 @@ module Preserve
 
     def session_key
       SessionKey.new(source_class, parameter_key).build
+    end
+
+    def parameters_to_hash(params)
+      params = params.to_unsafe_h if params.respond_to?(:to_unsafe_h)
+      params.to_hash
     end
   end
 end

--- a/lib/preserve/callback.rb
+++ b/lib/preserve/callback.rb
@@ -49,14 +49,14 @@ module Preserve
 
     def parameter_value
       keys = Array(parameter_key)
-      keys.reduce(params) { |h, k| h[k] if h.is_a?(HASH_CLASS) }
+      keys.reduce(params) { |h, k| h[k] if h.is_a?(PARAMETERS_CLASS) }
     end
 
     def parameter_value=(value)
       *keys, last_key = parameter_key
 
       nested_hash = keys.reduce(params) do |hash, key|
-        hash[key] ||= HASH_CLASS.new
+        hash[key] ||= PARAMETERS_CLASS.new
       end
 
       nested_hash[last_key] = value

--- a/lib/preserve/compatibility.rb
+++ b/lib/preserve/compatibility.rb
@@ -9,7 +9,7 @@ module Preserve
       :before_filter
     end
 
-  HASH_CLASS =
+  PARAMETERS_CLASS =
     if ActionPack::VERSION::MAJOR >= 4
       ActionController::Parameters
     else

--- a/spec/preserve_spec.rb
+++ b/spec/preserve_spec.rb
@@ -78,6 +78,18 @@ RSpec.describe Preserve, type: :request do
     expect(json_response[:sort][:direction]).to eq(nil)
   end
 
+  it 'handles a whole nested parameter' do
+    ParametersController.preserve(:sort)
+
+    params = { sort: { column: 'name', direction: 'desc' } }
+
+    get parameters_path, params: params
+    get parameters_path
+
+    expect(json_response[:sort][:column]).to eq('name')
+    expect(json_response[:sort][:direction]).to eq('desc')
+  end
+
   it 'sets a default parameter value' do
     ParametersController.preserve(:status, default: 'active')
 


### PR DESCRIPTION
With current implementation of `parameter_value`

```
def parameter_value
    keys = Array(parameter_key)
    keys.reduce(params) { |h, k| h[k] if h.is_a?(HASH_CLASS) }
end
```

you may end up  storing in session objects that are not native types (string, hash, array...)

Consider the following case. 
You have a nested parameter such as
```
{deep: { nested: {a: [1,2], b: 3}, d: 'e' }}
```
And you want to preserve the following
```
preserve [:deep, :nested]
```
If you are running a modern version of rails you are going to save in session an `ActionController::Parameters` instance which is not ideal.

```
(dev)> HASH_CLASS = ActionController::Parameters
=> ActionController::Parameters
(dev)> params = ActionController::Parameters.new(deep: { nested: {a: 12, b:3}, d: 'e' })
=> 
#<ActionController::Parameters {"deep" => {"nested" => {"a" => 12, "b" => 3}, "d...
(dev)> [:deep, :nested].reduce(params) { |h, k| h[k] if h.is_a?(HASH_CLASS)}
=> #<ActionController::Parameters {"a" => 12, "b" => 3} permitted: false>
(dev)> 
```

Storing non native type objects in session may lead to trouble with serialization.


I'm used to use `preserve` in combination with [activerecord-session_store](https://github.com/rails/activerecord-session_store) gem. In their latest release they removed `multi_json` as dependency in favor of std-lib `json` and here came troubles with serialization of non native objects

```
(dev)> value = ActionController::Parameters.new(test: {a: [1], b: 12})
=> #<ActionController::Parameters {"test" => {"a" => [1], "b" => 12}} permitted: false>
(dev)> 
(dev)> MultiJson.dump(value: value)
=> "{\"value\":{\"test\":{\"a\":[1],\"b\":12}}}"        <==== this is ok: can be parse as an hash
(dev)> JSON.dump(value: value)
=> "{\"value\":\"{\\\"test\\\" => {\\\"a\\\" => [1], \\\"b\\\" => 12}}\"}"        <==== this is not ok: can be parse as a string, not an hash!
(dev)> 
```


In this PR I just want to be sure to store in session just native types, casting to hash eventual `ActionController::Parameters` objects